### PR TITLE
wip: attempt at not using slow shapeless for (large) co-products

### DIFF
--- a/build/build.scala
+++ b/build/build.scala
@@ -15,5 +15,7 @@ class Build(val context: cbt.Context) extends XdotaiFreeSoftwareBuild{
     Resolver( mavenCentral ).bind(
       "com.chuusai" %% "shapeless" % "2.3.1",
       "org.cvogt" %% "scala-extensions" % "0.5.1"
+    ) ++ Seq(
+      DirectoryDependency(projectDirectory ++ "/macros")
     )
 }

--- a/macros/build/build.scala
+++ b/macros/build/build.scala
@@ -1,0 +1,8 @@
+import cbt._
+// cbt:https://github.com/cvogt/cbt.git#b5d86995128a45c33117ecfb7365f0eb2b450a61
+class Build(val context: cbt.Context) extends AdvancedScala{
+  override def dependencies = super.dependencies ++
+    Resolver( mavenCentral ).bind(
+      "org.scala-lang" % "scala-compiler" % "2.11.8"
+    )
+}

--- a/macros/macros.scala
+++ b/macros/macros.scala
@@ -1,0 +1,36 @@
+package ai.x.diff
+import scala.reflect.macros._
+
+final class Abstract[T]
+object Abstract{
+  def checkMacro[T:c.WeakTypeTag](c: blackbox.Context): c.Expr[Abstract[T]] = {
+    import c.universe._
+    val T = c.weakTypeOf[T]
+    if(
+      !T.typeSymbol.isAbstract
+    ) c.error(c.enclosingPosition,s"$T is not abstract")
+    c.Expr[Abstract[T]](q"new _root_.ai.x.diff.Abstract[$T]")
+  }
+  /**
+  fails compilation if T is not a singleton object class
+  meaning this can be used as an implicit to check
+  */
+  implicit def check[T]: Abstract[T] = macro checkMacro[T]
+}
+
+final class Sealed[T]
+object Sealed{
+  def checkMacro[T:c.WeakTypeTag](c: blackbox.Context): c.Expr[Sealed[T]] = {
+    import c.universe._
+    val T = c.weakTypeOf[T]
+    if(
+      !T.typeSymbol.isClass || !T.typeSymbol.asClass.isSealed
+    ) c.error(c.enclosingPosition,s"$T is not sealed")
+    c.Expr[Sealed[T]](q"new _root_.ai.x.diff.Sealed[$T]")
+  }
+  /**
+  fails compilation if T is not a singleton object class
+  meaning this can be used as an implicit to check
+  */
+  implicit def check[T]: Sealed[T] = macro checkMacro[T]
+}

--- a/test/Main.scala
+++ b/test/Main.scala
@@ -5,6 +5,7 @@ import java.util.UUID
 
 sealed trait Parent
 case class Bar( s: String, i: Int ) extends Parent
+case class Fooo( bar: Bar, b: List[Int], parent: Option[Int] ) extends Parent
 case class Foo( bar: Bar, b: List[Int], parent: Option[Parent] ) extends Parent
 
 case class Id(int: Int)
@@ -17,6 +18,18 @@ object Main extends App {
   val fooAsParent: Parent = foo
   val fooString = """Foo( b = Set(), bar = Bar( i = 1, s = "test" ), parent = None )"""
 
+  //implicitly[org.cvogt.scala.constraint.boolean.![org.cvogt.scala.constraint.SingletonObject[Foo]]]
+
+  //println(implicitly[DiffShow[Bar]](DiffShow.caseClassDiffShow).show(bar))
+  //implicitly[Lazy[DiffShow[Parent]]]
+  implicitly[DiffShow[Parent]]
+  //println(implicitly[DiffShow[Fooo]](DiffShow.caseClassDiffShow))
+  //println(implicitly[shapeless.LabelledGeneric[Bar]])
+  //println(implicitly[DiffShowFields[Bar]])
+  //println(implicitly[shapeless.LabelledGeneric[Foo]])
+  //println(implicitly[DiffShowFields[Foo]])
+  //println(implicitly[DiffShow[Foo]](DiffShow.caseClassDiffShow).show(foo))
+  /*
   def assertIdentical[T:DiffShow](left: T, right: T, expectedOutput: String = null) = {
     val c = DiffShow.diff(left, right)
     assert(c.isIdentical, c.toString)
@@ -203,5 +216,6 @@ object Main extends App {
     )
   )
   """
+  */
   */
 }

--- a/test/build/build.scala
+++ b/test/build/build.scala
@@ -3,4 +3,5 @@ import cbt._
 // cbt:https://github.com/cvogt/cbt.git#b5d86995128a45c33117ecfb7365f0eb2b450a61
 class Build(val context: Context) extends ScalaParadise{
   override def dependencies = super.dependencies :+ DirectoryDependency(projectDirectory.getParentFile)
+  //override def scalacOptions = super.scalacOptions ++ Seq( "-Xprint:typer")
 }


### PR DESCRIPTION
this is work in progress. it currently still leads to 

```
[error] /Users/chris/xdotai/diff/test/Main.scala:25: could not find implicit value for parameter e: ai.x.diff.DiffShow[Foo]
[error]   implicitly[DiffShow[Parent]]
[error]             ^
```
