### PR TITLE
updated custom comparison example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,13 @@ import ai.x.diff._
 Sometimes you may need to write your own type class instances. For example for non-case classes that don't compare well using ==.
 
 ```scala
+import ai.x.diff._
 import org.joda.time.LocalTime
-implicit def localTimeDiffShow: DiffShow[LocalTime] = new DiffShow[LocalTime]{
+
+implicit def localTimeDiffShow: DiffShow[LocalTime] = new DiffShow[LocalTime] {
   def show ( d: LocalTime ) = "LocalTime(" + d.toString + ")"
   def diff( l: LocalTime, r: LocalTime ) =
-    if ( l isEqual r ) Identical( show( l ) ) else Different( showChange( l, r ) )
+    if ( l isEqual r ) Identical( l ) else Different( l, r )
 }
 ```
 


### PR DESCRIPTION
Hi!

Came across your library today, which I find extremely useful.
Ran a couple of quick tests and noticed that documentation is possibly out of sync.

This example
```
import org.joda.time.LocalTime
implicit def localTimeDiffShow: DiffShow[LocalTime] = new DiffShow[LocalTime]{
  def show ( d: LocalTime ) = "LocalTime(" + d.toString + ")"
  def diff( l: LocalTime, r: LocalTime ) =
    if ( l isEqual r ) Identical( show( l ) ) else Different( showChange( l, r ) )
}
```
resulted in the following compile errors:
```
[error] aidiff/AiDiffTestSuite.scala:40: constructor Identical in class Identical cannot be accessed in <$anon: ai.x.diff.DiffShow[org.joda.time.LocalTime]>
[error]       if ( l isEqual r ) Identical( show( l ) ) else Different( showChange( l, r ) )
[error]                          ^
[error] aidiff/AiDiffTestSuite.scala:40: constructor Different in class Different cannot be accessed in <$anon: ai.x.diff.DiffShow[org.joda.time.LocalTime]>
[error]       if ( l isEqual r ) Identical( show( l ) ) else Different( showChange( l, r ) )
[error]                                                      ^
[error] two errors found
[error] (test:compileIncremental) Compilation failed
[error] Total time: 1 s, completed Mar 9, 2017 4:01:49 PM
```

This pull request adjusts the README so that the given example compiles fine.

Cheers,
Manfred